### PR TITLE
[fix] update default hash post-infura upgrade

### DIFF
--- a/v4/src/constants.js
+++ b/v4/src/constants.js
@@ -9,7 +9,7 @@ export const GRAPH_FILENAME = 'graph.json';
 export const DEFL_STORAGE = STORAGE_TYPES.IPFS;
 
 export const DEFL_STORAGE_OPTIONS = {
-  hash: 'QmWm3A6EdXYD12eaEjADs7iPnraEaYmK788QEHumQZ7yrH',
+  hash: 'bafyreicuan6hdr7jaz5e7pdevsjqjtviigil5achefs6lcwdaah5zc57le',
 };
 
 export const IOKS = [


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate your help improving the Index of Knowledge
-->

## Motivation

Small fix to update the default hash that gets loaded in if no storage options are specified. 

## Test Plan

Visit staging with updated hash

## Related PRs or Issues

Fix for #100 