### PR TITLE
Py scraper

### DIFF
--- a/.github/workflows/scraper.yaml
+++ b/.github/workflows/scraper.yaml
@@ -4,9 +4,8 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - master
+  schedule:
+    - cron: '0 */6 * * *'
 
 jobs:
   scrape-to-readme:

--- a/.github/workflows/scraper.yaml
+++ b/.github/workflows/scraper.yaml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  scape-to-readme:
+  scrape-to-readme:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ stages:
     if: branch = master AND type in (cron)
   - name: compile-v4
     if: branch = master AND sender != "Travis CI" AND type IN (pull_request)
-  - name: scrape-awesome
-    if: branch = master AND type IN (cron)
   - name: javascript-md-scraper
     if: branch = master AND sender != "Travis CI" AND type IN (pull_request)
   - name: ipfs-cytoscape
@@ -30,12 +28,6 @@ jobs:
       env:
         - DEPLOY_TARGET=beta
       script: "./compile_v4.sh"
-    - stage: scrape-awesome
-      language: python
-      python: 3.7
-      env:
-        - DEPLOY_TARGET=prod
-      script: "./deploy_scraper.sh && ./push.sh"
     - stage: javascript-md-scraper
       language: node_js
       before_install: cd v4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Decentralized Index of Knowledge (DIoK) is a curated collection of resources
 ## Table of Contents
 
 * [bitcoin](#bitcoin)
-* [computer science](#computer%20science)
+* [computer science](#computer-science)
 * [economics](#economics)
 * [math](#math)
 
@@ -15,7 +15,8 @@ The Decentralized Index of Knowledge (DIoK) is a curated collection of resources
 
 ### Description
 
-* [Bitcoin is an innovative payment network and a new kind of money.]()
+Bitcoin is an innovative payment network and a new kind of money.
+
 ### Papers
 
 * [Bitcoin: A Peer-to-Peer Electronic Cash System](https://bitcoin.org/bitcoin.pdf)
@@ -23,14 +24,17 @@ The Decentralized Index of Knowledge (DIoK) is a curated collection of resources
 
 ### Description
 
-* [Computer science is the study of processes that interact with data and that can be represented as data in the form of programs.]()
+Computer science is the study of processes that interact with data and that can be represented as data in the form of programs.
+
 ## economics
 
 ### Description
 
-* [Economics is the social science that studies the production, distribution, and consumption of goods and services.]()
+Economics is the social science that studies the production, distribution, and consumption of goods and services.
+
 ## math
 
 ### Description
 
-* [Mathematics is the study of abstract objects and structures that are often, but not always, abstracted from the physical world. It includes the study of such abstractions as quantity, structure, space and shapes, and change.]()
+Mathematics is the study of abstract objects and structures that are often, but not always, abstracted from the physical world. It includes the study of such abstractions as quantity, structure, space and shapes, and change.
+

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -21,8 +21,6 @@ chardet = "==3.0.4"
 idna = "==2.9"
 requests = "==2.23.0"
 urllib3 = "==1.25.9"
-py-cid = "*"
-ipfshttpclient ="*"
 
 [requires]
 python_version = "3.7"

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "887d3688d1002b2ba5a5348e1ea433f343058f3e221cb877f3e6e540637d744e"
+            "sha256": "0c189cadd57f0b9d33046bbeec6f03b36d216552f298b8c858264037513a28e8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,14 +16,6 @@
         ]
     },
     "default": {
-        "base58": {
-            "hashes": [
-                "sha256:1e42993c0628ed4f898c03b522b26af78fb05115732549b21a028bc4633d19ab",
-                "sha256:6aa0553e477478993588303c54659d15e3c17ae062508c854a8b752d07c716bd",
-                "sha256:9a793c599979c497800eb414c852b80866f28daaed5494703fc129592cc83e60"
-            ],
-            "version": "==1.0.3"
-        },
         "certifi": {
             "hashes": [
                 "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
@@ -63,14 +55,6 @@
             ],
             "index": "pypi",
             "version": "==2.9"
-        },
-        "ipfshttpclient": {
-            "hashes": [
-                "sha256:3f7b10919ca4158957aad194c20e34e8fb72296d9af015bd248a736ac9de1e6f",
-                "sha256:d777d91562b23813cf7aa17dbe362958087c3fcc8b98a16cbe42c562a7724055"
-            ],
-            "index": "pypi",
-            "version": "==0.6.0.post1"
         },
         "kiwisolver": {
             "hashes": [
@@ -117,26 +101,6 @@
             "index": "pypi",
             "version": "==3.2.1"
         },
-        "morphys": {
-            "hashes": [
-                "sha256:76d6dbaa4d65f597e59d332c81da786d83e4669387b9b2a750cfec74e7beec20"
-            ],
-            "version": "==1.0"
-        },
-        "multiaddr": {
-            "hashes": [
-                "sha256:30b2695189edc3d5b90f1c303abb8f02d963a3a4edf2e7178b975eb417ab0ecf",
-                "sha256:5c0f862cbcf19aada2a899f80ef896ddb2e85614e0c8f04dd287c06c69dac95b"
-            ],
-            "version": "==0.0.9"
-        },
-        "netaddr": {
-            "hashes": [
-                "sha256:9666d0232c32d2656e5e5f8d735f58fd6c7457ce52fc21c98d45f2af78f990ac",
-                "sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243"
-            ],
-            "version": "==0.8.0"
-        },
         "networkx": {
             "hashes": [
                 "sha256:cdfbf698749a5014bf2ed9db4a07a5295df1d3a53bf80bf3cbd61edf9df05fa1",
@@ -172,35 +136,6 @@
             "index": "pypi",
             "version": "==1.18.3"
         },
-        "py-cid": {
-            "hashes": [
-                "sha256:22f432cc6fb68d12a9c35dbdc92c95484fc49e31dfcb9e0efb0082233c5394e3",
-                "sha256:7c48a6ee0bc50fd114d4b24849cd689a31d3ad5bdf8fa073bf68f846fd58c5da"
-            ],
-            "index": "pypi",
-            "version": "==0.3.0"
-        },
-        "py-multibase": {
-            "hashes": [
-                "sha256:6ed706ea321b487ba82e4172a9c82d61dacd675c865f576a937a94bca1a23443",
-                "sha256:dde22b8d1c544e4636beefa1cf62c4131d25a57261c2b1c41f7d8a3f0142b4bc"
-            ],
-            "version": "==1.0.1"
-        },
-        "py-multicodec": {
-            "hashes": [
-                "sha256:55b6bb53088a63e56c434cb11b29795e8805652bac43d50a8f2a9bcf5ca84e1f",
-                "sha256:83021ffe8c0e272d19b5b86bc5b39efa67c8e9f4735ce6cafdbc1ace767ec647"
-            ],
-            "version": "==0.2.1"
-        },
-        "py-multihash": {
-            "hashes": [
-                "sha256:a0602c99093587dfbf1634e2e8c7726de39374b0d68587a36093b4c237af6969",
-                "sha256:f0ade4de820afdc4b4aaa40464ec86c9da5cae3a4578cda2daab4b0eb7e5b18d"
-            ],
-            "version": "==0.2.3"
-        },
         "pyparsing": {
             "hashes": [
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
@@ -208,12 +143,6 @@
             ],
             "index": "pypi",
             "version": "==2.4.7"
-        },
-        "python-baseconv": {
-            "hashes": [
-                "sha256:0539f8bd0464013b05ad62e0a1673f0ac9086c76b43ebf9f833053527cd9931b"
-            ],
-            "version": "==1.2.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -246,12 +175,6 @@
             ],
             "index": "pypi",
             "version": "==1.25.9"
-        },
-        "varint": {
-            "hashes": [
-                "sha256:a6ecc02377ac5ee9d65a6a8ad45c9ff1dac8ccee19400a5950fb51d594214ca5"
-            ],
-            "version": "==1.0.2"
         }
     },
     "develop": {
@@ -293,29 +216,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a",
-                "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938",
-                "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29",
-                "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae",
-                "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387",
-                "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a",
-                "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf",
-                "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610",
-                "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9",
-                "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5",
-                "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3",
-                "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89",
-                "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded",
-                "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754",
-                "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f",
-                "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868",
-                "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd",
-                "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910",
-                "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3",
-                "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac",
-                "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"
+                "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204",
+                "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162",
+                "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f",
+                "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb",
+                "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6",
+                "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7",
+                "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88",
+                "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99",
+                "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644",
+                "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a",
+                "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840",
+                "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067",
+                "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd",
+                "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4",
+                "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e",
+                "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89",
+                "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e",
+                "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc",
+                "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf",
+                "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341",
+                "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"
             ],
-            "version": "==2020.6.8"
+            "version": "==2020.7.14"
         },
         "toml": {
             "hashes": [

--- a/python/src/iok/meta.py
+++ b/python/src/iok/meta.py
@@ -213,18 +213,17 @@ class AwesomeClient:
         link = dat["link"]
         return f"* [{text}]({link})\n"
 
-    def get_nodedata(self, dat):
+    def get_nodedata(self, dat, resource_type):
         """Formats a node's data.
         Like get_s or get_link, but handles any type of node data."""
-        if isinstance(dat, str):
-            return self.get_s(dat)
-        if "link" in dat:
+        if resource_type == ResourceType.DESCRIPTION:
+            return self.get_s(dat["text"])
+        else:
             return self.get_link(dat)
-        return self.get_s(dat["text"])
 
     def escape_toc_link_txt(self, s):
         """spaces in toc link need to be escaped, among others"""
-        return re.sub(r"\s+", "%20", s)
+        return re.sub(r"\s+", "-", s)
 
     def get_toc_link(self, title):
         """Generate link that references title on the same doc"""
@@ -266,7 +265,7 @@ class AwesomeClient:
             if len(node[hkey]):
                 s += self.get_h(hname, level=3)
                 for x in node[hkey]:
-                    s += self.get_nodedata(x)
+                    s += self.get_nodedata(x, hkey)
         return s
 
     def write_to_file(self, filename):

--- a/python/src/scraper/scrape.py
+++ b/python/src/scraper/scrape.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python
 import requests
-import sys
 from iok.meta import KnowledgeGraph, AwesomeClient
 
 

--- a/python/src/scraper/tests/test_data.py
+++ b/python/src/scraper/tests/test_data.py
@@ -137,7 +137,10 @@ TEST_DATA = {
             {
                 "data": {
                     "resource_type": 1,
-                    "data": "a dish of Italian origin consisting of a flat, round base of dough baked with a topping of tomato sauce and cheese, typically with added meat or vegetables.",
+                    "data": {
+                        "link": "",
+                        "text": "a dish of Italian origin consisting of a flat, round base of dough baked with a topping of tomato sauce and cheese, typically with added meat or vegetables.",
+                    },
                     "node_type": 2,
                     "id": "512b6a3b60506b05da1d61426bd3214b58c2765d29c1db8d76460d23c3a40373",
                     "name": "res-512b6a3b60",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate your help improving the Index of Knowledge
-->

## Motivation

Depends on #108.

Adds scraper GHA workflow that uses the ipfs client from #108 to get the full graph, and then invokes the python scraper to linearize into markdown. Does not commit to source just yet. Some changes:
* `iok.vars` to keep track of canonical IoK CID
* some minor changes to python scraper, primarily to take in iok json file, and updates to resource data format that were never caught.
* bonus resolves #18 

## Test Plan

CI scrape job, and also test local, which resulted in the updated README (goodbye 🍕)

## Related PRs or Issues

Resolves #109 