### PR TITLE
[v4] node traversed toggle

### DIFF
--- a/v4/src/Graph.jsx
+++ b/v4/src/Graph.jsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import IokEdit from './IokEdit';
 import {
-  addNode, editNode, deleteNode, mergeNode, selectNode, selectMergeNode, uploadGraph, importGraph,
+  addNode, editNode, deleteNode, mergeNode, selectNode, selectMergeNode, toggleNodeTraversed, uploadGraph, importGraph,
 } from './redux/actions';
 
 const mapStateToProps = (state) => {
@@ -13,6 +13,7 @@ const mapStateToProps = (state) => {
     graph: state.graph,
     selected: state.selected,
     mergingNode: state.mergingNode,
+    traversed: state.traversed,
   };
 };
 
@@ -23,6 +24,7 @@ const mapDispatchToProps = (dispatch) => ({
   mergeNode: (fromId, toId) => dispatch(mergeNode(fromId, toId)),
   selectNode: (id) => dispatch(selectNode(id)),
   selectMergeNode: (id) => dispatch(selectMergeNode(id)),
+  toggleNodeTraversed: (id) => dispatch(toggleNodeTraversed(id)),
   uploadGraph: (graph) => dispatch(uploadGraph(graph)),
   importGraph: (graph) => dispatch(importGraph(graph)),
 });

--- a/v4/src/IokText.jsx
+++ b/v4/src/IokText.jsx
@@ -3,14 +3,14 @@
 /* eslint-disable no-alert */
 import React from 'react';
 import { PropTypes } from 'prop-types';
-// import Log from './log';
+import Log from './log';
 // import './styles/IokText.css';
 import './IokText.css';
 
 // import { GRAPH_FILENAME } from './constants';
 import { NTYPE } from './types';
 
-function IokText({ node }) {
+function IokText({ node, traversed, toggleNodeTraversed }) {
   const data = node ? node.data : {
     name: 'Overview',
     data: { text: 'Index of Knowledge (IoK) is a curated collection of resources for blockchain, grouped by topic and topologically ordered by pedagogical dependency.' },
@@ -22,7 +22,8 @@ function IokText({ node }) {
   const depList = [];
   const descList = [];
   const linkList = [];
-
+  const traversedNodes = [];
+  
   // eslint-disable-next-line no-restricted-syntax
   for (const neighbor of neighbors) {
     if (neighbor.node_type === NTYPE.TOPIC) { // topic is dep
@@ -39,6 +40,18 @@ function IokText({ node }) {
   // XXX: HACK!! if no node is selected, we use a linkList alongside a descList
   if (!node) {
     linkList.push(<li key="dummy"><a href=".">Resource links appear here!</a></li>);
+  }
+
+  // list the traversed nodes for debugging
+  traversed.forEach(el => {
+    traversedNodes.push(<li className="nodeid" key={el}>{el}</li>)
+  })
+
+  let toggleBtnText = "Mark as learned";
+  if (data.id) {
+    if (traversed.has(data.id)) {
+      toggleBtnText = "You learned this";
+    }
   }
 
   return (
@@ -107,6 +120,15 @@ function IokText({ node }) {
             {' '}
             <h3 className="heading">Debugging</h3>
             <p className="nodeid">{data.id}</p>
+            <button type="button" className="tool filledButton" onClick={() => {
+              Log.info(`Toggling nodde traversed: ${data.id}`)
+              toggleNodeTraversed(data.id);
+            }}>{toggleBtnText}</button>
+            <div className="section linksection">
+              <ul id="travsednodes">
+                {traversedNodes}
+              </ul>
+            </div>
           </div>
         )
       }

--- a/v4/src/Sidebar.jsx
+++ b/v4/src/Sidebar.jsx
@@ -2,31 +2,35 @@ import { connect } from 'react-redux';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  mergeNode, selectNode, selectMergeNode,
+  mergeNode, selectNode, selectMergeNode, toggleNodeTraversed
 } from './redux/actions';
 import IokText from './IokText';
 
 const mapStateToProps = (state) => ({
   selected: state.selected,
   mergingNode: state.mergingNode,
+  traversed: state.traversed,
 });
 
 const mapDispatchToProps = (dispatch) => ({
   mergeNode: (fromId, toId) => dispatch(mergeNode(fromId, toId)),
   selectNode: (id) => dispatch(selectNode(id)),
   selectMergeNode: (id) => dispatch(selectMergeNode(id)),
+  toggleNodeTraversed: (id) => dispatch(toggleNodeTraversed(id)),
 });
 
-const FullSideBar = ({ mergingNode, selected }) => (
+const FullSideBar = ({ mergingNode, selected, traversed, toggleNodeTraversed }) => (
   <div>
-    {mergingNode ? <IokText node={mergingNode} /> : <div />}
-    <IokText node={selected} />
+    {mergingNode ? <IokText node={mergingNode} traversed={traversed} toggleNodeTraversed={toggleNodeTraversed}/> : <div />}
+    <IokText node={selected} traversed={traversed} toggleNodeTraversed={toggleNodeTraversed}/>
   </div>
 );
 
 FullSideBar.propTypes = {
   mergingNode: PropTypes.object, // eslint-disable-line
   selected: PropTypes.object, // eslint-disable-line
+  traversed: PropTypes.object, // eslint-disable-line
+  toggleNodeTraversed: PropTypes.func, // eslint-disable-line
 };
 
 const Sidebar = connect(mapStateToProps, mapDispatchToProps)(FullSideBar);

--- a/v4/src/redux/actions.js
+++ b/v4/src/redux/actions.js
@@ -5,6 +5,7 @@ export const ACTION_TYPES = {
   MERGE_NODE: 'MERGE_NODE',
   SELECT_NODE: 'SELECT_NODE',
   SELECT_MERGE_NODE: 'SELECT_MERGE_NODE',
+  TOGGLE_NODE_TRAVERSED: 'TOGGLE_NODE_TRAVERSED',
   UPLOAD_GRAPH: 'UPLOAD_GRAPH',
   IMPORT_GRAPH: 'IMPORT_GRAPH',
 };
@@ -39,6 +40,11 @@ export const selectNode = (nodeId) => ({
 
 export const selectMergeNode = (nodeId) => ({
   type: ACTION_TYPES.SELECT_MERGE_NODE,
+  nodeId,
+});
+
+export const toggleNodeTraversed = (nodeId) => ({
+  type: ACTION_TYPES.TOGGLE_NODE_TRAVERSED,
   nodeId,
 });
 

--- a/v4/src/redux/reducers/index.js
+++ b/v4/src/redux/reducers/index.js
@@ -5,7 +5,7 @@ import {
   outgoers, calcCurrentNode,
 } from './graphlib';
 
-const DEFAULT_STATE = { graph: { elements: {} }, selected: null, mergingNode: null };
+const DEFAULT_STATE = { graph: { elements: {} }, selected: null, mergingNode: null, traversed: new Set() };
 
 function graphToElements(graph) {
   let elements = [];
@@ -15,7 +15,7 @@ function graphToElements(graph) {
 }
 
 export default function reducer(state = DEFAULT_STATE, action) {
-  let { graph, selected, mergingNode } = state;
+  let { graph, selected, mergingNode, traversed } = state;
   const elements = graphToElements(state.graph);
   const cy = Cytoscape({ elements });
 
@@ -57,6 +57,15 @@ export default function reducer(state = DEFAULT_STATE, action) {
       graph = graphHelper(cy);
       break;
     }
+    case ACTION_TYPES.TOGGLE_NODE_TRAVERSED: {
+      traversed = new Set(traversed);
+      if (traversed.has(action.nodeId)) {
+        traversed.delete(action.nodeId);
+      } else {
+        traversed.add(action.nodeId);
+      }
+      break;
+    }
     case ACTION_TYPES.UPLOAD_GRAPH: {
       graph = action.graph;
       break;
@@ -81,5 +90,6 @@ export default function reducer(state = DEFAULT_STATE, action) {
     graph,
     selected,
     mergingNode,
+    traversed,
   };
 }


### PR DESCRIPTION
Adds actions and reducers for toggling node traversals. Traversals are
stored in a separate Set from the actual IoK graph because we want the
hash of the IoK graph to be consistent, and store all other metadata
separately. In general:

```
{
    graph: <IoK graph, resolves to canonical CID>,
    traversed: <list of traversed node IDs>,
    ...<other metadata>..
}
```

For test, added a button for debugging in `IokText`. Because this
component is functional however, we cannot force update the state and
re-render the component. Instead, for now, we need to change the
selected node to see the updates to the traversed node set.

Updated staging env: https://iok-rustie.firebaseapp.com/

Next steps:
* clean up the UI, perhaps mouse gesture instead of button (#95)
* update storage save/load operations will operate on traversal states 

Resolves #94